### PR TITLE
fix: reject invalid CAST identifier segments

### DIFF
--- a/bishopfox_connector.py
+++ b/bishopfox_connector.py
@@ -43,7 +43,10 @@ class RetVal(tuple):
 
 def _quote_path_segment(value):
     """Encode an action-supplied identifier as one URL path segment."""
-    return urlparse.quote(str(value), safe="").replace(".", "%2E")
+    value = str(value)
+    if value in {".", ".."}:
+        raise ValueError("Finding and subject identifiers cannot be dot path segments")
+    return urlparse.quote(value, safe="").replace(".", "%2E")
 
 
 class BishopFoxConnector(BaseConnector):
@@ -370,7 +373,10 @@ class BishopFoxConnector(BaseConnector):
             err_msg = "Please provide a valid 'status' action parameter from the value list"
             return action_result.set_status(phantom.APP_ERROR, err_msg)
 
-        endpoint = f"/findings/{_quote_path_segment(finding_uid)}/subjects/{_quote_path_segment(subject_uid)}/status"
+        try:
+            endpoint = f"/findings/{_quote_path_segment(finding_uid)}/subjects/{_quote_path_segment(subject_uid)}/status"
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
         data = {"status": consts.STATUS_CODES[status]}
 
@@ -399,7 +405,10 @@ class BishopFoxConnector(BaseConnector):
         subject_uid = param.get("subject_uid")
         client_id = param["client_id"]
 
-        endpoint = f"/findings/{_quote_path_segment(finding_uid)}/subjects/{_quote_path_segment(subject_uid)}/clientid"
+        try:
+            endpoint = f"/findings/{_quote_path_segment(finding_uid)}/subjects/{_quote_path_segment(subject_uid)}/clientid"
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
         data = {"clientId": client_id}
 
@@ -428,7 +437,10 @@ class BishopFoxConnector(BaseConnector):
         subject_uid = param.get("subject_uid")
         client_note = param["client_note"]
 
-        endpoint = f"/findings/{_quote_path_segment(finding_uid)}/subjects/{_quote_path_segment(subject_uid)}/clientnote"
+        try:
+            endpoint = f"/findings/{_quote_path_segment(finding_uid)}/subjects/{_quote_path_segment(subject_uid)}/clientnote"
+        except ValueError as e:
+            return action_result.set_status(phantom.APP_ERROR, str(e))
 
         data = {"clientNote": client_note}
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Reject dot path segments in CAST finding and subject identifiers before endpoint construction.


### PR DESCRIPTION
## Summary

- reject finding or subject identifiers exactly equal to `.` or `..` before endpoint construction
- preserve full path-segment encoding for slash, query, fragment, and encoded variants
- apply the same validation to status, client-ID, and client-note updates

## Validation context

This follows source validation for [PAPP-38096](https://splunk.atlassian.net/browse/PAPP-38096), [PSAAS-31336](https://splunk.atlassian.net/browse/PSAAS-31336), and [VULN-94061](https://splunk.atlassian.net/browse/VULN-94061), under [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228). It follows merged PR #13.

The manifest calls these UUIDs, but subject IDs remain optional for two actions. This follow-up avoids silently converting optional parameters into a breaking requirement; any future UUID-only schema change should be handled as an explicit major-version change. The connector repository has no runnable BaseConnector unit-test harness, so the full app-linter/static pre-commit suite and direct inspection of all three prepared targets form the regression gate.

## Quality gate

- source compile passed
- `pre-commit run --all-files` passed

Authored by Codex.